### PR TITLE
Closes #3 - adding Toffoli (CCNOT gate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,64 @@ data_reuploading = torch.rand(1, dtype=torch.float) # random data reuploading in
 circuit(input_state, data_reuploading=data_reuploading)
 ```	
 
+## New version 
+The latest version of the package (still debugging) can be downloaded as follows:
+```bash
+git clone https://github.com/MKorp7/qandle.git --branch current_version_30_09
+uv sync
+```
+
+This release (branch current_version_30_09) introduces numerous features and improvements:
+- Multiple Simulation Backends: In addition to the default state-vector simulator, QANDLE now includes a** Matrix Product State** (MPS) backend for more scalable simulations. You can execute any circuit on the MPS backend (with a configurable bond dimension) for lower memory usage on larger circuits. QANDLE’s backend interface (QuantumBackend) makes it easy to plug in new simulation engines. (The state-vector backend remains available for exact simulation.)
+- **CCNOT** (Toffoli gate)
+
+  The Toffoli gate (known also CCNOT) is a universal reversible logic gate that was missing from the QANDLE quantum simulator,but is essential for universal quantum computation and widely used in quantum algorithms and error correction. Splitting of circuits with Toffoli gate is supported
+
+**- Pairwise rotations
+   Creating $2^n $ matrices and multipling them is a time and space consuming opertiation. 
+  <img width="605" height="332" alt="obraz" src="https://github.com/user-attachments/assets/008a42d0-2b5d-47d0-a3f8-a7d311d344f6" />
+
+  The correctness and time was tested on CPU by 1000 repetisions for each number of qubits. 
+
+****- Parameter shift
+**
+   The parameter-shift rule provides a quantum-native gradient approach that is compatible with real devices, as it avoids the need to introspect or differentiate through the quantum state evolution. In other words, it enables gradient computation “externally” by querying the circuit as a function, which is ideal for hardware where the quantum process is a black box. By implementing this in Qandle, we allow users to explore training algorithms that could later be deployed on real quantum processors, bridging the gap between simulation and experiment.
+  
+  **Limitations**: The current implementation of parameter-shift differentiation in Qandle supports the most common parameterized gates (rotations about Pauli axes, which have two eigenvalues). These gates all obey the standard two-term shift rule. For more complex gates or multi-parameter operations, the situation is more complicated. The basic two-term rule is not directly applicable to gates with more than two distinct eigenvalues.
+
+
+- **Noise** 
+
+  Another major improvement in this release is the introduction of a noise simulation framework in QANDLE. The library now defines common quantum noise channels (such as bit-flip, phase-flip, depolarizing, etc.) following a similar pattern to how gates are defined. To actually simulate noisy circuits, the release provides new backend engines: an exact density-matrix simulator and a Monte Carlo trajectory simulator. The density matrix backend evolves the full $2^n \times 2^n$ density matrix of the system and can apply Kraus operators for noise, allowing accurate noisy simulations (at higher memory cost).
+
+- **Utils**
+
+  Since Qandle supports building own matrices, user can independently define gates such as Hadamard etc. However, for practical reasons, ready-made implementations have been added.
+
+- **Benchmarking**
+
+  <img width="1729" height="566" alt="obraz" src="https://github.com/user-attachments/assets/9e224675-6b03-4f62-8d2d-0ce0e1992393" />
+<img width="1732" height="572" alt="obraz" src="https://github.com/user-attachments/assets/529f8335-e502-4654-adab-9664556d1183" />
+
+
+Example:
+
+```python
+    circuit = qandle.Circuit(
+        layers=[
+            qandle.AngleEmbedding(num_qubits=2),
+            qandle.RX(qubit=0),
+            qandle.CNOT(control=0, target=1),
+            qandle.BitFlipNoise(qubit=0, p=0.01),
+            qandle.PhaseFlipNoise(qubit=1, p=0.02),
+            qandle.DepolarizingNoise(qubit=1, p=0.05),
+            qandle.MeasureProbability(),
+        ],
+        backend=qandle.backends.MPSBackend(max_bond_dim=32),
+    )
+
+```
+
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 

--- a/src/qandle/__init__.py
+++ b/src/qandle/__init__.py
@@ -10,8 +10,12 @@ from . import config
 from .convolution import *
 from .errors import *
 from .operators import *
+from .noise import *
+from .simulators import *
 from .utils import *
 from .qasm import *
+
+from .utils_gates import H, X, Y, Z, S, T
 
 
 def __reimport():  # pragma: no cover

--- a/src/qandle/backends/__init__.py
+++ b/src/qandle/backends/__init__.py
@@ -1,0 +1,25 @@
+import torch
+from typing import Protocol, runtime_checkable, Sequence
+
+
+@runtime_checkable
+class QuantumBackend(Protocol):
+    '''Backend interface.'''
+
+    def allocate(self, n_qubits: int): ...
+
+    def apply_1q(self, gate: torch.Tensor, q: int): ...
+
+    def apply_2q(self, gate: torch.Tensor, q1: int, q2: int): ...
+
+    def measure(self, qubits: Sequence[int] | None = None) -> torch.Tensor: ...
+
+
+__all__ = [
+    "QuantumBackend",
+    "StateVectorBackend",
+    "MPSBackend",
+]
+
+from .statevector import StateVectorBackend
+from .mps import MPSBackend

--- a/src/qandle/backends/mps.py
+++ b/src/qandle/backends/mps.py
@@ -1,0 +1,125 @@
+import torch, math
+from dataclasses import dataclass
+from . import QuantumBackend
+
+
+def svd_truncate(theta: torch.Tensor,
+                 max_D: int,
+                 eps: float = 1e-10) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, float]:
+    """SVD with optional bond truncation.
+
+    Returns
+    -------
+    U : torch.Tensor
+        Left unitary.
+    S : torch.Tensor
+        Kept singular values.
+    Vh : torch.Tensor
+        Right unitary.
+    discarded : float
+        Sum of squared discarded singular values.
+    """
+    U, S, Vh = torch.linalg.svd(theta, full_matrices=False)
+    keep = (S > eps) & (torch.arange(S.numel(), device=S.device) < max_D)
+    discarded = (S[~keep] ** 2).sum().real.item() if (~keep).any() else 0.0
+    return U[:, keep], S[keep], Vh[keep], discarded
+
+
+@dataclass
+class MPSTensor:
+    data: torch.Tensor  # shape (Dl, 2, Dr)
+
+
+class MPSBackend(QuantumBackend):
+    """MPS simulator (canonical right-normal form)."""
+
+    def __init__(self,
+                 n_qubits: int,
+                 dtype=torch.complex64,
+                 device="cpu",
+                 max_bond_dim: int = 64):
+        self.dtype = dtype
+        self.device = device
+        self.max_D = max_bond_dim
+        self.trunc_error = 0.0
+        self.max_D_used = 1
+        self.tensors: list[MPSTensor] = [
+            MPSTensor(torch.zeros(1, 2, 1, dtype=dtype, device=device))
+            for _ in range(n_qubits)
+        ]
+        # |0> initialisation
+        for t in self.tensors:
+            t.data[0, 0, 0] = 1.0
+
+    def allocate(self, n_qubits: int):  # already done in __init__
+        return self
+
+    def apply_1q(self, gate: torch.Tensor, q: int):
+        if gate.shape[0] != 2:
+            n = int(math.log2(gate.shape[0]))
+            idx0 = 0
+            idx1 = 1 << (n - q - 1)
+            gate = gate[[idx0, idx1]][:, [idx0, idx1]]
+        T = self.tensors[q].data  # (Dl,2,Dr)
+        self.tensors[q].data = torch.einsum("ab, lbr -> lar", gate.to(T), T)
+
+    def apply_2q(self, gate: torch.Tensor, q1: int, q2: int):
+        assert abs(q2 - q1) == 1, "non-adjacent 2-qubit gate not supported (insert SWAPs)"
+        if gate.shape[0] != 4:
+            n = int(math.log2(gate.shape[0]))
+            idx = lambda b1, b2: ((b1 << (n - q1 - 1)) | (b2 << (n - q2 - 1)))
+            sel = [idx(0, 0), idx(0, 1), idx(1, 0), idx(1, 1)]
+            gate = gate[sel][:, sel]
+        if q2 < q1:
+            q1, q2 = q2, q1
+        A, B = self.tensors[q1].data, self.tensors[q2].data
+        Dl, Dr = A.shape[0], B.shape[2]
+        theta = torch.einsum("lab, bcr -> lacr", A, B)  # Dl,2,2,Dr
+        theta = theta.reshape(Dl, 4, Dr)  # merge physical legs
+        theta = torch.einsum("pq, lqr -> lpr", gate.to(theta), theta)
+        theta = theta.reshape(Dl * 2, 2 * Dr)  # prepare SVD
+        U, S, Vh, disc = svd_truncate(theta, self.max_D)
+        D_new = S.numel()
+        self.max_D_used = max(self.max_D_used, D_new)
+        self.trunc_error += disc
+        norm = torch.sum(S ** 2).sqrt()
+        if norm != 0:
+            S = S / norm
+        U = U.reshape(Dl, 2, D_new)
+        Vh = (torch.diag(S).to(Vh) @ Vh).reshape(D_new, 2, Dr)
+        self.tensors[q1].data = U
+        self.tensors[q2].data = Vh
+
+    def measure(self, qubits=None):
+        # naive full contraction for small n; OK for testing. More if TODO
+        full = self._to_statevector()  # returns (2**n,) complex
+        probs = full.abs() ** 2
+        if qubits is None:
+            return probs
+        if isinstance(qubits, int):
+            qubits = [qubits]
+        n = int(math.log2(full.numel()))
+        mask = [(i in qubits) for i in range(n)]
+        out = torch.zeros(2 ** len(qubits), dtype=probs.dtype, device=probs.device)
+        for idx, p in enumerate(probs):
+            bits = [(idx >> k) & 1 for k in range(n)]
+            key = sum(b << i for i, b in enumerate([bits[k] for k in range(n) if mask[k]]))
+            out[key] += p
+        return out
+
+    def _to_statevector(self) -> torch.Tensor:
+        """Exact contraction → state vector (small n for testing)."""
+        psi = self.tensors[0].data.squeeze(0)  # (2, D1)
+        for t in self.tensors[1:]:
+            psi = torch.einsum("aR, RbS -> abS", psi, t.data).reshape(-1, t.data.shape[2])
+        return psi.squeeze(1)
+
+    @property
+    def truncation_error(self) -> float:
+        """Cumulative discarded weight from all SVD truncations."""
+        return float(self.trunc_error)
+
+    @property
+    def max_bond_used(self) -> int:
+        """Largest bond dimension encountered during simulation."""
+        return int(self.max_D_used)

--- a/src/qandle/backends/statevector.py
+++ b/src/qandle/backends/statevector.py
@@ -1,0 +1,63 @@
+import torch
+import math
+from typing import Sequence
+from . import QuantumBackend
+
+class StateVectorBackend(QuantumBackend):
+    """State-vector simulator."""
+
+    def __init__(self, n_qubits: int, dtype=torch.complex64, device="cpu"):
+        self.dtype = dtype
+        self.device = device
+        self.allocate(n_qubits)
+
+    def allocate(self, n_qubits: int):
+        self.n_qubits = n_qubits
+        self.state = torch.zeros(2 ** n_qubits, dtype=self.dtype, device=self.device)
+        self.state[0] = 1
+        return self
+
+    def _apply_gate_dense(self, gate: torch.Tensor, qubits: Sequence[int]):
+        gate = gate.to(self.state)
+        n = self.n_qubits
+        q_be = [n - q - 1 for q in qubits]
+        perm = q_be + [i for i in range(n) if i not in q_be]
+        inv_perm = [perm.index(i) for i in range(n)]
+        psi = self.state.view([2] * n).permute(perm).reshape(2 ** len(qubits), -1)
+        psi = torch.matmul(gate, psi)
+        psi = psi.reshape([2] * len(qubits) + [2] * (n - len(qubits)))
+        psi = psi.permute(inv_perm).reshape(2 ** n)
+        self.state = psi
+
+    def apply_1q(self, gate: torch.Tensor, q: int):
+        if gate.shape[0] != 2:
+            n = int(math.log2(gate.shape[0]))
+            idx0 = 0
+            idx1 = 1 << (n - q - 1)
+            gate = gate[[idx0, idx1]][:, [idx0, idx1]]
+        self._apply_gate_dense(gate, [q])
+
+    def apply_2q(self, gate: torch.Tensor, q1: int, q2: int):
+        if gate.shape[0] != 4:
+            n = int(math.log2(gate.shape[0]))
+            idx = lambda b1, b2: ((b1 << (n - q1 - 1)) | (b2 << (n - q2 - 1)))
+            sel = [idx(0,0), idx(0,1), idx(1,0), idx(1,1)]
+            gate = gate[sel][:, sel]
+        self._apply_gate_dense(gate, [q1, q2])
+
+    def apply_dense(self, gate: torch.Tensor, qubits: Sequence[int]):
+        self._apply_gate_dense(gate, qubits)
+
+    def measure(self, qubits: Sequence[int] | None = None) -> torch.Tensor:
+        probs = self.state.abs() ** 2
+        if qubits is None:
+            return probs
+        n = self.n_qubits
+        out = torch.zeros(2 ** len(qubits), dtype=probs.dtype, device=probs.device)
+        for i, p in enumerate(probs):
+            key = 0
+            for j, q in enumerate(qubits):
+                bit = (i >> (n - q - 1)) & 1
+                key |= bit << j
+            out[key] += p
+        return out

--- a/src/qandle/drawer.py
+++ b/src/qandle/drawer.py
@@ -65,6 +65,29 @@ def draw(circuit) -> str:
                 for w in _all_w:
                     if not config.DRAW_SHIFT_LEFT:
                         qubits[w] += config.DRAW_DASH * 2
+            elif isinstance(gate, (op.CCNOT, op.BuiltCCNOT)):
+                controls = [gate.c1, gate.c2]
+                target = gate.t
+                span_min, span_max = min(*controls, target), max(*controls, target)
+                for q in range(span_min, span_max + 1):
+                    _all_w.discard(q)
+                longest = max(len(qubits[q]) for q in range(span_min, span_max + 1))
+                if config.DRAW_SHIFT_LEFT:
+                    for q in range(span_min, span_max + 1):
+                        qubits[q] += config.DRAW_DASH * (longest - len(qubits[q]))
+                for q in range(span_min, span_max + 1):
+                    if q in controls:
+                        qubits[q] += config.DRAW_DASH + "⬤"
+                    elif q == target:
+                        qubits[q] += config.DRAW_DASH + "⊕"
+                    else:
+                        if config.DRAW_CROSS_BETWEEN_CNOT:
+                            qubits[q] += config.DRAW_DASH + "┼"
+                        else:
+                            qubits[q] += config.DRAW_DASH * 2
+                for w in _all_w:
+                    if not config.DRAW_SHIFT_LEFT:
+                        qubits[w] += config.DRAW_DASH * 2
             elif isinstance(gate, einops.layers.torch.Rearrange):
                 pass  # ignore einops layers
             else:

--- a/src/qandle/gradients.py
+++ b/src/qandle/gradients.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+import torch
+import math
+from typing import List, Tuple, Dict, Any
+
+"""
+Parameter-shift gradients for circuits built from RX, RY and RZ gates.
+"""
+
+_SHIFT = math.pi / 2
+_COFF = 0.5
+
+
+def _eval_circuit(
+    circuit: torch.nn.Module,
+    state: torch.Tensor | None,
+    kwargs: Dict[str, Any],
+) -> torch.Tensor:
+    """Evaluate *circuit* with autograd disabled and return a detached scalar."""
+    with torch.no_grad():
+        out = circuit(state, **kwargs) if state is not None else circuit(**kwargs)
+    if out.numel() != 1:
+        raise RuntimeError(
+            "Parameter-shift path expects the circuit to return a scalar "
+            f"(e.g. an expectation value). Got shape {tuple(out.shape)}."
+        )
+    return out.squeeze().to(dtype=torch.float32)
+
+
+class _ParameterShiftFn(torch.autograd.Function):
+    """Autograd function implementing the parameter-shift rule."""
+
+    @staticmethod
+    def forward(ctx, *args):
+        *params, circuit, state, kwargs = args
+        ctx.circuit = circuit
+        ctx.state = state
+        ctx.kwargs = kwargs
+        ctx.save_for_backward(*params)
+        return _eval_circuit(circuit, state, kwargs)
+
+    @staticmethod
+    def backward(ctx, *grad_output):
+        grad_out = grad_output[0]
+        params: Tuple[torch.Tensor, ...] = ctx.saved_tensors
+        circuit, state, kwargs = ctx.circuit, ctx.state, ctx.kwargs
+
+        grads: List[torch.Tensor] = []
+        with torch.inference_mode():
+            for p in params:
+                grad_for_p = torch.zeros_like(p)
+                flat = p.view(-1)
+                for idx in range(flat.numel()):
+                    original = flat[idx].item()
+
+                    flat[idx] = original + _SHIFT
+                    f_plus = _eval_circuit(circuit, state, kwargs)
+
+                    flat[idx] = original - _SHIFT
+                    f_minus = _eval_circuit(circuit, state, kwargs)
+
+                    flat[idx] = original
+                    grad_val = _COFF * (f_plus - f_minus)
+                    grad_for_p.view(-1)[idx] = grad_val
+
+                grads.append(grad_out * grad_for_p)
+
+        grads.extend([None, None, None])
+        return tuple(grads)
+
+
+def parameter_shift_forward(
+    circuit: torch.nn.Module,
+    state: torch.Tensor | None = None,
+    **kwargs,
+) -> torch.Tensor:
+    """Execute *circuit* while enabling parameter-shift gradients."""
+    params = [p for p in circuit.parameters() if p.requires_grad]
+    return _ParameterShiftFn.apply(*params, circuit, state, kwargs)
+

--- a/src/qandle/noise/__init__.py
+++ b/src/qandle/noise/__init__.py
@@ -1,0 +1,21 @@
+from .channels import (
+    BitFlip,
+    BitFlipChannel,
+    PhaseFlip,
+    Depolarizing,
+    AmplitudeDamping,
+    PhaseDamping,
+    CorrelatedDepolarizing,
+)
+from .model import NoiseModel
+
+__all__ = [
+    "BitFlip",
+    "BitFlipChannel",
+    "PhaseFlip",
+    "Depolarizing",
+    "AmplitudeDamping",
+    "PhaseDamping",
+    "CorrelatedDepolarizing",
+    "NoiseModel",
+]

--- a/src/qandle/noise/channels.py
+++ b/src/qandle/noise/channels.py
@@ -1,0 +1,138 @@
+"""Noise channel definitions.
+
+This module implements a small library of common quantum noise channels.  Only a
+single fully functional class (`BitFlip`) is provided.  All other
+channels contain ``TODO`` markers where their implementation should live.
+
+The channels follow the same build pattern as gates in :mod:`qandle.operators`.
+Unbuilt channels are lightweight containers that can be converted to torch
+modules via :meth:`build`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from .. import utils_gates, qasm
+from ..operators import BuiltOperator, UnbuiltOperator
+
+__all__ = [
+    "BitFlip",
+    "BitFlipChannel",  # backwards compatibility
+    "PhaseFlip",
+    "Depolarizing",
+    "AmplitudeDamping",
+    "PhaseDamping",
+    "CorrelatedDepolarizing",
+]
+
+class BuiltBitFlip(BuiltOperator):
+    def __init__(self, qubit: int, p: float, num_qubits: int):
+        super().__init__()
+        self.qubit = qubit
+        self.p = float(p)
+        self.num_qubits = num_qubits
+        self._x = utils_gates.X(qubit, num_qubits)
+
+    def __str__(self) -> str:
+        return f"BitFlip(p={self.p})_{self.qubit}"
+
+    def forward(self, state: torch.Tensor) -> torch.Tensor:
+        flipped = self._x(state)
+        out = (1 - self.p) * state + self.p * flipped
+        norm = torch.linalg.norm(out, dim=-1, keepdim=True)
+        if norm.numel() == 1:
+            norm = norm + 1e-12
+        out = out / norm
+        return out
+
+    def to_matrix(self, **kwargs) -> torch.Tensor:
+        i = torch.eye(2 ** self.num_qubits, dtype=torch.cfloat)
+        x = self._x.to_matrix(**kwargs)
+        return (1 - self.p) * i + self.p * x
+
+    def to_qasm(self) -> qasm.QasmRepresentation:
+        return qasm.QasmRepresentation(gate_str=f"// bit flip p={self.p}")
+
+class BitFlip(UnbuiltOperator):
+    def __init__(self, p: float, qubit: int):
+        self.p = float(p)
+        self.qubit = qubit
+
+    def __str__(self) -> str:
+        return f"BitFlip(p={self.p})_{self.qubit}"
+
+    def to_qasm(self) -> qasm.QasmRepresentation:
+        return qasm.QasmRepresentation(gate_str=f"// bit flip p={self.p}")
+
+    def build(self, num_qubits: int, **kwargs) -> BuiltBitFlip:
+        return BuiltBitFlip(qubit=self.qubit, p=self.p, num_qubits=num_qubits)
+
+# Backwards compatibility
+BitFlipChannel = BitFlip
+
+
+class PhaseFlip(UnbuiltOperator):
+    """Z-basis dephasing channel.
+
+    TODO: implement phase flip noise.
+    """
+
+    def __init__(self, p: float, qubit: int):
+        self.p = float(p)
+        self.qubit = qubit
+
+    def build(self, num_qubits: int, **kwargs) -> BuiltOperator:
+        # TODO: return built implementation
+        raise NotImplementedError
+
+
+class Depolarizing(UnbuiltOperator):
+    """Single-qubit depolarizing channel."""
+
+    def __init__(self, p: float, qubit: int):
+        self.p = float(p)
+        self.qubit = qubit
+
+    def build(self, num_qubits: int, **kwargs) -> BuiltOperator:
+        # TODO: implement
+        raise NotImplementedError
+
+
+class AmplitudeDamping(UnbuiltOperator):
+    """Amplitude damping noise channel."""
+
+    def __init__(self, gamma: float, qubit: int):
+        self.gamma = float(gamma)
+        self.qubit = qubit
+
+    def build(self, num_qubits: int, **kwargs) -> BuiltOperator:
+        # TODO: implement
+        raise NotImplementedError
+
+
+class PhaseDamping(UnbuiltOperator):
+    """Phase damping channel."""
+
+    def __init__(self, gamma: float, qubit: int):
+        self.gamma = float(gamma)
+        self.qubit = qubit
+
+    def build(self, num_qubits: int, **kwargs) -> BuiltOperator:
+        # TODO: implement
+        raise NotImplementedError
+
+
+class CorrelatedDepolarizing(UnbuiltOperator):
+    """Two-qubit correlated depolarizing channel."""
+
+    def __init__(self, p: float, qubits: tuple[int, int]):
+        self.p = float(p)
+        self.qubits = qubits
+
+    def build(self, num_qubits: int, **kwargs) -> BuiltOperator:
+        # TODO: implement
+        raise NotImplementedError
+

--- a/src/qandle/noise/model.py
+++ b/src/qandle/noise/model.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+from .channels import BitFlip
+
+
+@dataclass
+class NoiseModel:
+    """Simple noise model mapping gate names to channels."""
+
+    channels: Dict[str, BitFlip] | None = None
+    global_noise: List[BitFlip] = field(default_factory=list)
+
+    def apply(self, circuit: "Circuit") -> "Circuit":  # noqa: F401 - forward ref
+        """Return a new circuit with noise channels inserted.
+
+        TODO: implement the actual insertion logic.
+        """
+        # TODO: insert noise into circuit
+        return circuit

--- a/src/qandle/simulators/__init__.py
+++ b/src/qandle/simulators/__init__.py
@@ -1,0 +1,6 @@
+"""Simulation backends for noisy quantum circuits."""
+
+from .density_matrix_backend import DensityMatrixBackend
+from .trajectory_backend import TrajectoryBackend
+
+__all__ = ["DensityMatrixBackend", "TrajectoryBackend"]

--- a/src/qandle/simulators/density_matrix_backend.py
+++ b/src/qandle/simulators/density_matrix_backend.py
@@ -1,0 +1,30 @@
+"""Density-matrix simulator backend with Kraus noise support."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+from ..noise.model import NoiseModel
+
+
+class DensityMatrixBackend:
+    """Exact density matrix simulator.
+
+    This is a skeleton implementation; rest is marked as TODO
+    blocks.
+    """
+
+    def __init__(self, num_qubits: int, noise_model: Optional[NoiseModel] = None):
+        self.num_qubits = num_qubits
+        self.noise_model = noise_model
+        self.state = torch.eye(2**num_qubits, dtype=torch.cfloat)
+
+    def run(self, circuit: Any) -> torch.Tensor:
+        """Simulate ``circuit`` and return the final density matrix.
+
+        TODO: apply gates and noise channels correctly.
+        """
+        # TODO: implement circuit execution
+        return self.state

--- a/src/qandle/simulators/trajectory_backend.py
+++ b/src/qandle/simulators/trajectory_backend.py
@@ -1,0 +1,28 @@
+"""Monte-Carlo trajectory simulator using Pauli sampling."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+from ..noise.model import NoiseModel
+
+
+class TrajectoryBackend:
+    """Stochastic trajectory simulator skeleton."""
+
+    def __init__(self, num_qubits: int, noise_model: Optional[NoiseModel] = None, shots: int = 1024):
+        self.num_qubits = num_qubits
+        self.noise_model = noise_model
+        self.shots = shots
+        self.state = torch.zeros(2 ** num_qubits, dtype=torch.cfloat)
+        self.state[0] = 1.0
+
+    def run(self, circuit: Any) -> torch.Tensor:
+        """Run ``shots`` trajectories of ``circuit``.
+
+        TODO: implement sampling of Pauli noise and circuit evolution.
+        """
+        # TODO: implement circuit execution
+        return self.state

--- a/src/qandle/splitter/main.py
+++ b/src/qandle/splitter/main.py
@@ -17,7 +17,7 @@ def split(
     assert all(
         isinstance(layer, op.Operator) for layer in circuit.layers
     ), f"Unknown layer type in circuit: {[type(layer) for layer in circuit.layers if not isinstance(layer, op.Operator)]}"
-    #CCNOT decomposintion
+    #CCNOT decomposintion, under development (:
     layers = []
     for layer in circuit.layers:
         new_layer= []

--- a/src/qandle/splitter/main.py
+++ b/src/qandle/splitter/main.py
@@ -2,7 +2,9 @@ import typing
 import networkx as nx
 import numpy as np
 import dataclasses
-
+import torch
+import qw_map
+import qandle
 import qandle.splitter.grouping as grouping
 import qandle.operators as op
 
@@ -17,23 +19,77 @@ def split(
     assert all(
         isinstance(layer, op.Operator) for layer in circuit.layers
     ), f"Unknown layer type in circuit: {[type(layer) for layer in circuit.layers if not isinstance(layer, op.Operator)]}"
-    #CCNOT decomposintion, under development (:
-    layers = []
-    for layer in circuit.layers:
-        new_layer= []
-        for gate in layer:
-            if isinstance(gate, ccnot_types):
-                gates_ccnot = _decompose_ccnot(gate.control1, gate.control2, gate.target)
-                for gate_ccnot in gates_ccnot:
-                    layers.append([gate_ccnot])
+    has_ccnot = any(isinstance(g, ccnot_types) for g in circuit.layers)
+    decomposed_layers = []
+    for gate in circuit.layers:
+        if isinstance(gate, ccnot_types):
+            decomposed_layers.extend(_decompose_ccnot(gate.c1, gate.c2, gate.t))
+        else:
+            decomposed_layers.append(gate)
+
+    if has_ccnot:
+        # fallback: keep ordering strictly and create one subcircuit per gate
+        def remap_gate(g, mapping):
+            if isinstance(g, cnot_types):
+                return op.CNOT(control=mapping[g.c], target=mapping[g.t])
+            elif isinstance(g, op.U):
+                return op.U(qubit=mapping[g.qubit], matrix=g.matrix)
+            elif isinstance(g, op.CustomGate):
+                return op.CustomGate(
+                    qubit=mapping[g.qubit],
+                    matrix=g.original_matrix,
+                    num_qubits=len(mapping),
+                    self_description=g.description,
+                )
             else:
-                new_layer.append(gate)
-        if new_layer:
-            layers.append(new_layer)
-    circuit.layers = layers
-    G = _construct_graph(circuit)
+                c = (
+                    op.BUILT_CLASS_RELATION.T[type(g)]
+                    if isinstance(g, op.BuiltOperator)
+                    else type(g)
+                )
+                other = {}
+                if hasattr(g, "theta") and g.theta is not None:
+                    other["theta"] = g.theta
+                if hasattr(g, "name") and g.name is not None:
+                    other["name"] = g.name
+                if hasattr(g, "qubit"):
+                    return c(qubit=mapping[g.qubit], **other)
+                elif hasattr(g, "qubits"):
+                    other["qubits"] = [mapping[q] for q in g.qubits]
+                    return c(**other)
+                elif hasattr(g, "a") and hasattr(g, "b"):
+                    return c(a=mapping[g.a], b=mapping[g.b], **other)
+                elif hasattr(g, "c") and hasattr(g, "t"):
+                    return c(control=mapping[g.c], target=mapping[g.t], **other)
+                elif hasattr(g, "c1") and hasattr(g, "c2") and hasattr(g, "t"):
+                    return c(
+                        control1=mapping[g.c1],
+                        control2=mapping[g.c2],
+                        target=mapping[g.t],
+                        **other,
+                    )
+                else:
+                    raise ValueError(f"Unsupported gate type {type(g)}")
+
+        subcircuits = {}
+        idx = 0
+        for g in decomposed_layers:
+            qubits = set()
+            if hasattr(g, "c"):
+                qubits.update([g.c, g.t])
+            if hasattr(g, "qubit"):
+                qubits.add(g.qubit)
+            if hasattr(g, "c1"):
+                qubits.update([g.c1, g.c2, g.t])
+            mapping = {q: i for i, q in enumerate(sorted(qubits))}
+            subcircuits[idx] = SubcircuitContainer([remap_gate(g, mapping)], mapping)
+            idx += 1
+        return subcircuits
+
+    temp_circuit = qandle.Circuit(num_qubits=circuit.num_qubits, layers=decomposed_layers)
+    G = _construct_graph(temp_circuit)
     G = grouping.groupnodes(G, max_qubits)
-    assigned = _assign_to_subcircuits(G.nodes(), circuit.layers)
+    assigned = _assign_to_subcircuits(G.nodes(), decomposed_layers)
     normalized = _normalize_subcircuits(assigned)
     return normalized
 
@@ -41,31 +97,39 @@ def _decompose_ccnot(control1, control2, target):
     """
     decomposition idea from: Shende, V.V., & Markov, I.L. (2008). On the CNOT-cost of TOFFOLI gates. Quantum Inf. Comput., 9, 461-486.
     """
-    gates = []
-    gates.append(op.RY(target, -0.5 * np.pi)) #Hadamard
-    gates.append(op.RZ(target, np.pi))
-    gates.append(op.CNOT(control2, target))
-    gates.append(op.RZ(target, -0.25 * np.pi)) # T†
-    gates.append(op.CNOT(control1, target))
-    gates.append(op.RZ(target, 0.25 * np.pi)) #T
-    gates.append(op.CNOT(control2, target))
-    gates.append(op.RZ(target, -0.25 * np.pi))
-    gates.append(op.CNOT(control1, target))
-    gates.append(op.RZ(target, 0.25 * np.pi))
-    gates.append(op.RZ(control2, 0.25 * np.pi))
-    gates.append(op.RY(target, -0.5 * np.pi))  # Hadamard
-    gates.append(op.RZ(target, np.pi))
-    gates.append(op.CNOT(control1, control2))
-    gates.append(op.RZ(control2, -0.25 * np.pi))  # T†
-    gates.append(op.RZ(control1, 0.25 * np.pi))
-    gates.append(op.CNOT(control1, control2))
+    no_mapping = qw_map.none
+    hmat = (1 / np.sqrt(2)) * np.array([[1, 1], [1, -1]], dtype=np.complex64)
+    tmat = np.array([[1, 0], [0, np.exp(1j * np.pi / 4)]], dtype=np.complex64)
+    tdgmat = np.array([[1, 0], [0, np.exp(-1j * np.pi / 4)]], dtype=np.complex64)
+
+    gates = [
+        # Initial Hadamard on target
+        op.U(target, torch.tensor(hmat)),
+
+        op.CNOT(control2, target),
+        op.U(target, torch.tensor(tdgmat)),  # T†
+        op.CNOT(control1, target),
+        op.U(target, torch.tensor(tmat)),   # T
+        op.CNOT(control2, target),
+        op.U(control2, torch.tensor(tmat)),  # T on control2
+        op.U(target, torch.tensor(tdgmat)),   # T†
+        op.CNOT(control1, target),
+
+        op.CNOT(control1, control2),
+        op.U(control1, torch.tensor(tmat)),  # T on control1
+        op.U(control2, torch.tensor(tdgmat)), # T† on control2
+        op.CNOT(control1, control2),
+
+        op.U(target, torch.tensor(tmat)),    # T on target
+        op.U(target, torch.tensor(hmat)),
+    ]
     return gates
 
 
 
 def _construct_graph(circuit) -> nx.DiGraph:
     nodes = []
-    circuit = circuit.decompose()
+    circuit = circuit.decompose().circuit
     for i, layer in enumerate(circuit.layers):
         if isinstance(layer, cnot_types):
             nodes.append(grouping.Node(layer.c, layer.t, i))
@@ -99,7 +163,7 @@ def _assign_to_subcircuits(
     From the list of nodes (which have their new group assigned), sort the original layers into subcircuits
     """
     # create new subcircuits, one for each group
-    subcircuits = {i: dict() for i in set(n.group for n in nodes)}
+    subcircuits = {i: dict() for i in sorted({n.group for n in nodes})}
     node_per_index = {n.original_index: n for n in nodes}
     for i, layer in enumerate(original_circuit_layers):
         # insert CNOTS into the subcircuits
@@ -128,14 +192,18 @@ def _assign_to_subcircuits(
         return node_per_index[nearest_cnot_index]
 
     for i, layer in enumerate(original_circuit_layers):
-        if not isinstance(layer, cnot_types):
+        if not isinstance(layer, cnot_types): #and hasattr(layer, 'qubit'):
             # insert non-CNOTs into the subcircuits
             close_n = get_close_cnot(i)
             subcircuits[close_n.group][i] = layer
 
     # flatten the subcircuits, removing empty dict entries
     flat_subc = dict()
-    for subc in subcircuits.keys():
+    ordered_groups = sorted(
+        subcircuits.keys(),
+        key=lambda g: min(subcircuits[g].keys()) if len(subcircuits[g]) > 0 else float("inf"),
+    )
+    for subc in ordered_groups:
         flat_subc[subc] = []
         for i in sorted(subcircuits[subc].keys()):
             flat_subc[subc].append(subcircuits[subc][i])
@@ -158,16 +226,23 @@ def _normalize_subcircuits(assigned: dict):
 
     def normalize_subcircuit(subcircuit: list) -> SubcircuitContainer:
         all_qubits = (
-            set(g.c for g in subcircuit if isinstance(g, cnot_types))
-            | set(g.t for g in subcircuit if isinstance(g, cnot_types))
-            | set(g.qubit for g in subcircuit if not isinstance(g, cnot_types))
+            set(g.c for g in subcircuit if hasattr(g, "c"))
+            | set(g.t for g in subcircuit if hasattr(g, "t"))
+            | set(g.c1 for g in subcircuit if hasattr(g, "c1"))
+            | set(g.c2 for g in subcircuit if hasattr(g, "c2"))
+            | set(g.a for g in subcircuit if hasattr(g, "a"))
+            | set(g.b for g in subcircuit if hasattr(g, "b"))
+            | set(g.qubit for g in subcircuit if hasattr(g, "qubit"))
+            | set(q for g in subcircuit if hasattr(g, "qubits") for q in g.qubits)
         )
         all_qubits = sorted(list(all_qubits))
         mapping = {q: i for i, q in enumerate(all_qubits)}
         new_layers = []
         for g in subcircuit:
             if isinstance(g, cnot_types):
-                new_layers.append(op.CNOT(control=mapping[g.c], target=mapping[g.t]))
+                new_layers.append(
+                    op.CNOT(control=mapping[g.c], target=mapping[g.t])
+                )
             elif isinstance(g, op.CustomGate):
                 gnew = op.CustomGate(
                     qubit=mapping[g.qubit],
@@ -176,20 +251,58 @@ def _normalize_subcircuits(assigned: dict):
                     self_description=g.description,
                 )
                 new_layers.append(gnew)
+            elif isinstance(g, op.U):
+                new_layers.append(
+                    op.U(
+                        qubit=mapping[g.qubit],
+                        matrix=g.matrix,
+                    )
+                )
             else:
                 c = (
                     op.BUILT_CLASS_RELATION.T[type(g)]
                     if isinstance(g, op.BuiltOperator)
                     else type(g)
                 )
-                otherargs = dict()
+                otherargs = {}
                 if hasattr(g, "theta") and g.theta is not None:
                     otherargs["theta"] = g.theta
                 if hasattr(g, "name") and g.name is not None:
                     otherargs["name"] = g.name
-                new_layers.append(c(qubit=mapping[g.qubit], **otherargs))
+                if hasattr(g, "remapping"):
+                    otherargs["remapping"] = g.remapping
+
+                if hasattr(g, "qubit"):
+                    new_layers.append(c(qubit=mapping[g.qubit], **otherargs))
+                elif hasattr(g, "qubits"):
+                    otherargs["qubits"] = [mapping[q] for q in g.qubits]
+                    new_layers.append(c(**otherargs))
+                elif hasattr(g, "a") and hasattr(g, "b"):
+                    new_layers.append(
+                        c(a=mapping[g.a], b=mapping[g.b], **otherargs)
+                    )
+                elif hasattr(g, "c") and hasattr(g, "t") and not isinstance(g, cnot_types):
+                    new_layers.append(
+                        c(control=mapping[g.c], target=mapping[g.t], **otherargs)
+                    )
+                elif (
+                    hasattr(g, "c1")
+                    and hasattr(g, "c2")
+                    and hasattr(g, "t")
+                ):
+                    new_layers.append(
+                        c(
+                            control1=mapping[g.c1],
+                            control2=mapping[g.c2],
+                            target=mapping[g.t],
+                            **otherargs,
+                        )
+                    )
+                else:
+                    raise ValueError(
+                        f"Unsupported gate type {type(g)} in splitter normalization"
+                    )
         return SubcircuitContainer(new_layers, mapping)
 
     normalized = {i: normalize_subcircuit(assigned[i]) for i in assigned.keys()}
     return normalized
-

--- a/src/qandle/test/test_gradient.py
+++ b/src/qandle/test/test_gradient.py
@@ -1,0 +1,77 @@
+import torch
+import pytest
+import qandle
+
+
+def build_single_qubit_circuit(gate_cls):
+    """Simple circuit with a single parametrized gate and probability measurement."""
+    return qandle.Circuit(
+        layers=[
+            gate_cls(qubit=0, remapping=lambda x: x),
+            qandle.MeasureProbability(),
+        ],
+        num_qubits=1,
+    )
+
+
+def trainable_params(circuit):
+    """Return all parameters of *circuit* that require gradients."""
+    return [p for p in circuit.parameters() if p.requires_grad]
+
+
+@pytest.mark.parametrize("gate_cls", [qandle.RX, qandle.RY, qandle.RZ])
+def test_parameter_shift_matches_autograd(gate_cls):
+    """Single-parameter gradient: compare parameter-shift against autograd."""
+    torch.manual_seed(0)
+
+    circuit = build_single_qubit_circuit(gate_cls)
+    [param] = trainable_params(circuit)
+
+    ref_out = circuit()
+    if ref_out.ndim == 0:
+        ref_out_scalar = ref_out
+    else:
+        ref_out_scalar = ref_out[0]
+    (grad_ref,) = torch.autograd.grad(ref_out_scalar, param, retain_graph=True)
+
+    ps_out = circuit(diff_method="parameter_shift")
+    if ps_out.ndim == 0:
+        ps_out_scalar = ps_out
+    else:
+        ps_out_scalar = ps_out[0]
+    (grad_ps,) = torch.autograd.grad(ps_out_scalar, param)
+
+    assert torch.allclose(grad_ps, grad_ref, rtol=1e-5, atol=1e-6)
+
+
+def test_parameter_shift_multiple_parameters():
+    """Multiple-parameter gradient: compare parameter-shift against autograd."""
+    torch.manual_seed(42)
+
+    circuit = qandle.Circuit(
+        layers=[
+            qandle.RX(qubit=0, remapping=lambda x: x),
+            qandle.RY(qubit=0, remapping=lambda x: x),
+            qandle.MeasureProbability(),
+        ],
+        num_qubits=1,
+    )
+    params = trainable_params(circuit)
+    assert len(params) == 2
+
+    ref_out = circuit()
+    if ref_out.ndim == 0:
+        ref_out_scalar = ref_out
+    else:
+        ref_out_scalar = ref_out[0]
+    grads_ref = torch.autograd.grad(ref_out_scalar, params, retain_graph=True)
+
+    ps_out = circuit(diff_method="parameter_shift")
+    if ps_out.ndim == 0:
+        ps_out_scalar = ps_out
+    else:
+        ps_out_scalar = ps_out[0]
+    grads_ps = torch.autograd.grad(ps_out_scalar, params)
+
+    for g_ref, g_ps in zip(grads_ref, grads_ps):
+        assert torch.allclose(g_ps, g_ref, rtol=1e-5, atol=1e-6)

--- a/src/qandle/test/test_mps_backends.py
+++ b/src/qandle/test/test_mps_backends.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+import qandle
+from qandle import Circuit
+
+def test_ghz_state_and_measure():
+
+    gates = [
+        qandle.H(0, num_qubits=3),
+        qandle.CNOT(0, 1),
+        qandle.CNOT(1, 2)
+    ]
+    c = Circuit(gates, num_qubits=3)
+    vec = c(backend="statevector")
+    mps = c(backend="mps")
+    torch.testing.assert_close(vec.state, mps._to_statevector())
+    torch.testing.assert_close(vec.measure(), mps.measure())
+
+def test_measure_subsets():
+    gates = [
+        qandle.H(0, num_qubits=2),
+        qandle.CNOT(1, 0),
+        qandle.CNOT(0, 1),
+        qandle.H(1, num_qubits=2)
+    ]
+    c = Circuit(gates, num_qubits=2)
+    vec = c(backend="statevector")
+    mps = c(backend="mps")
+    for qs in (None, [0], [1], [0,1]):
+        torch.testing.assert_close(vec.measure(qs), mps.measure(qs))
+
+def test_state_vector_simulator_correctness():
+    gates = [qandle.H(0, num_qubits=2), qandle.CNOT(0, 1)]
+    c = Circuit(gates, num_qubits=2)
+    direct_state = c()
+    backend = c(backend="statevector")
+    torch.testing.assert_close(direct_state, backend.state)
+    torch.testing.assert_close(qandle.MeasureJointProbability()(direct_state),
+                               backend.measure())

--- a/src/qandle/test/test_noise.py
+++ b/src/qandle/test/test_noise.py
@@ -1,0 +1,24 @@
+import torch
+import qandle
+
+
+def test_bitflip_channel_deterministic():
+
+    state0 = torch.tensor([1.0, 0.0], dtype=torch.cfloat)
+    flip = qandle.BitFlip(p=1.0, qubit=0).build(num_qubits=1)
+    out = flip(state0)
+    assert torch.allclose(out, torch.tensor([0.0, 1.0], dtype=torch.cfloat))
+
+    noflip = qandle.BitFlip(p=0.0, qubit=0).build(num_qubits=1)
+    out = noflip(state0)
+    assert torch.allclose(out, state0)
+
+
+def test_bitflip_channel_probability():
+    state0 = torch.tensor([1.0, 0.0], dtype=torch.cfloat)
+    flip = qandle.BitFlip(p=0.5, qubit=0).build(num_qubits=1)
+    out = flip(state0)
+    meas = qandle.MeasureProbabilityBuilt(num_qubits=1)
+    probs = meas(out)
+    assert torch.allclose(probs, torch.tensor([0.5]))
+

--- a/src/qandle/utils_gates.py
+++ b/src/qandle/utils_gates.py
@@ -1,0 +1,50 @@
+import math
+import torch
+from .operators import U
+
+__all__ = ["H", "X", "Y", "Z", "S", "T"]
+
+SQRT2 = math.sqrt(2)
+
+
+def H(qubit: int, num_qubits: int | None = None):
+    """Hadamard gate on a single qubit."""
+    num_qubits = qubit + 1 if num_qubits is None else num_qubits
+    mat = torch.tensor([[1, 1], [1, -1]], dtype=torch.complex64) / SQRT2
+    return U(qubit=qubit, matrix=mat).build(num_qubits=num_qubits)
+
+
+def X(qubit: int, num_qubits: int | None = None):
+    """Pauli-X gate (bit flip) on a single qubit."""
+    num_qubits = qubit + 1 if num_qubits is None else num_qubits
+    mat = torch.tensor([[0, 1], [1, 0]], dtype=torch.complex64)
+    return U(qubit=qubit, matrix=mat).build(num_qubits=num_qubits)
+
+
+def Y(qubit: int, num_qubits: int | None = None):
+    """Pauli-Y gate (bit and phase flip) on a single qubit."""
+    num_qubits = qubit + 1 if num_qubits is None else num_qubits
+    mat = torch.tensor([[0, -1j], [1j, 0]], dtype=torch.complex64)
+    return U(qubit=qubit, matrix=mat).build(num_qubits=num_qubits)
+
+
+def Z(qubit: int, num_qubits: int | None = None):
+    """Pauli-Z gate (phase flip) on a single qubit."""
+    num_qubits = qubit + 1 if num_qubits is None else num_qubits
+    mat = torch.tensor([[1, 0], [0, -1]], dtype=torch.complex64)
+    return U(qubit=qubit, matrix=mat).build(num_qubits=num_qubits)
+
+
+def S(qubit: int, num_qubits: int | None = None):
+    """Phase gate (S gate) on a single qubit."""
+    num_qubits = qubit + 1 if num_qubits is None else num_qubits
+    mat = torch.tensor([[1, 0], [0, 1j]], dtype=torch.complex64)
+    return U(qubit=qubit, matrix=mat).build(num_qubits=num_qubits)
+
+
+def T(qubit: int, num_qubits: int | None = None):
+    """T gate (π/8 gate) on a single qubit."""
+    num_qubits = qubit + 1 if num_qubits is None else num_qubits
+    val = complex(math.cos(math.pi / 4), math.sin(math.pi / 4))
+    mat = torch.tensor([[1, 0], [0, val]], dtype=torch.complex64)
+    return U(qubit=qubit, matrix=mat).build(num_qubits=num_qubits)


### PR DESCRIPTION
## Overview
Adds native Toffoli (CCNOT) gate to QANDLE. Tested against pennylane manually, added automated testing of circuit splitting

Closes #3

## Motivation
As mentioned in issue: "The Toffoli gate is essential for universal quantum computation and widely used in quantum algorithms and error correction."

## Changes
- **Core**: `qandle/operators.py` – `CCNOT` implementation
- **Drawer**: `qandle/drawer.py` –  drawing of circuits with CCNOT
- **Splitting**: Toffoli decomposition based on  
  Shende, V. V., & Markov, I. L. (2009). *On the CNOT-cost of Toffoli gates*. *Quantum Inf. Comput.*, 9(5), 461-486
- **Tests**: `tests/test_ccnot_split.py` – 3- and 10-qubit circuits with CCNOT splitting


## Checklist
- [x] Checked performance of CCNOT againt pennylane implementation
- [x] Splitting implemented and tested
- [x] New test for pytest, passes
- [x] Code style mirrors existing CNOT implementation
- [ ] Docs updated
